### PR TITLE
fixing in linux

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -12,12 +12,15 @@ class LambertConan(ConanFile):
     default_options = "shared=False"
     generators = "cmake"
 
+    def configure(self):
+        del self.settings.compiler.libcxx
+
     def source(self):
         self.run("git clone https://github.com/yageek/lambert.git")
         self.run("cd lambert && git checkout 2.0.1")
         # This small hack might be useful to guarantee proper /MT /MD linkage in MSVC
         # if the packaged project doesn't have variables to set it properly
-        tools.replace_in_file("lambert/CMakeLists.txt", "PROJECT(lambert)", '''PROJECT(lambert)
+        tools.replace_in_file("lambert/CMakeLists.txt", "project(lambert)", '''project(lambert)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()''')
 
@@ -36,3 +39,5 @@ conan_basic_setup()''')
 
     def package_info(self):
         self.cpp_info.libs = ["lambert"]
+        if self.settings.os == "Linux":
+            self.cpp_info.libs.append("m")

--- a/test_package/example.cpp
+++ b/test_package/example.cpp
@@ -1,5 +1,9 @@
 #include <iostream>
-#include "lambert.h"
+
+extern "C"{
+    #include "lambert.h"
+}
+
 
 int main() {
     //Declares origin point and translated point


### PR DESCRIPTION
This fixes the issue https://github.com/conan-io/conan/issues/1369

The problem is that you were including a pure C header in a C++ program. You can do 2 things:

- Convert the test_package program to C. This is not difficult.
- Use the ``extern "C"`` to include it

I have also done several minor modifications:

- remove the ``libcxx`` settings. It is a pure C, it doesn't link with the C++ standard library, so not affected
- Added linkage to the math library, only for linux. You might want to extend this for OSX too.
- there was a mistake in the replacement. Not critical, because Lambert doesn't have other dependencies, but otherwise would fail. The substitution was not being done because of a difference in letter case.

Please tell me if this help in OSX too. Cheers!